### PR TITLE
Concurrent mocks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 layout node
+PATH_add bin

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -2,25 +2,13 @@ const test = require('ava')
 const Link = require('../src')
 
 test('requires a URL', t => {
-  function ctorWithNoParameters () {
-    return new Link()
-  }
-
-  t.throws(ctorWithNoParameters, Error)
+  t.throws(() => new Link(), Error)
 })
 
 test('requires at least one path segment', t => {
-  function ctorWithNoPath () {
-    return new Link(dbUrl)
-  }
-
-  t.throws(ctorWithNoPath, Error)
+  t.throws(() => new Link(dbUrl), Error)
 })
 
 test('requires the query directory to exist', t => {
-  function ctorWithFakePath () {
-    return new Link(dbUrl, __dirname, 'does-not-exist')
-  }
-
-  t.throws(ctorWithFakePath, Error)
+  t.throws(() => new Link(dbUrl, __dirname, 'does-not-exist'), Error)
 })

--- a/test/pg.js
+++ b/test/pg.js
@@ -8,7 +8,6 @@ const dbUrl = 'pg:///test'
 let db
 
 test.cb.before(t => {
-  Link.useRealConnections()
   db = new Link(dbUrl, __dirname, 'sql')
   pg.connect(dbUrl, (err, client, close) => {
     if (err) return t.end(err)

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -12,7 +12,6 @@ let clock
 test.before(t => {
   clock = sinon.useFakeTimers()
   sinon.stub(pg, 'connect')
-  Link.useRealConnections()
   db = new Link(dbUrl, __dirname, 'sql')
 })
 

--- a/test/types.js
+++ b/test/types.js
@@ -20,11 +20,7 @@ class Custom {
   }
 }
 
-test.before(t => {
-  Link.useRealConnections()
-})
-
-test.serial('materializes counts as int', t => {
+test('materializes counts as int', t => {
   int8Parser = pg.types.getTypeParser(20)
   Link.parseInt8AsJsNumber()
   return db


### PR DESCRIPTION
Currently, mocking is done globally - all connections are either real or mocked, and mock functions are installed globally. This means tests can't be run concurrently.

This change introduces `MockingScope`, which allows each test to have it's own mocking scope. Each scope has its own set of mocked functions, and a Link class which uses them. The Link class can be injected into routes to mock out database queries.